### PR TITLE
Uses ENTRYPOINT instead of CMD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ USER user
 ENV USER user
 ENV HOME /home/user
 ENV XDG_RUNTIME_DIR=/run/user/1000
-CMD ["/usr/bin/forge"]
+ENTRYPOINT ["/usr/bin/forge"]


### PR DESCRIPTION
this makes it more intuitive to leverage flags as args to the image run