### PR TITLE
Support secure registries via API type option

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@dominodatalab/platform
+* @dominodatalab/platform

--- a/api/v1alpha1/containerimagebuild_types.go
+++ b/api/v1alpha1/containerimagebuild_types.go
@@ -53,6 +53,10 @@ type ContainerImageBuildSpec struct {
 	// an image of any size will be pushed.
 	// +kubebuilder:validation:Optional
 	ImageSizeLimit uint64 `json:"imageSizeLimit"`
+
+	// Push image to an insecure registry.
+	// +kubebuilder:validation:Optional
+	InsecureRegistry bool `json:"insecureRegistry"`
 }
 
 // ContainerImageBuildStatus defines the observed state of ContainerImageBuild

--- a/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
+++ b/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
@@ -63,6 +63,9 @@ spec:
                 pushed to a registry. By default, an image of any size will be pushed.
               format: int64
               type: integer
+            insecureRegistry:
+              description: Push image to an insecure registry.
+              type: boolean
             labels:
               additionalProperties:
                 type: string

--- a/config/samples/forge_v1alpha1_containerimagebuild.yaml
+++ b/config/samples/forge_v1alpha1_containerimagebuild.yaml
@@ -7,7 +7,7 @@ spec:
   imageName: multi-stage-app
 
   # push image here after build
-  pushRegistry: 192.168.64.80:30000
+  pushRegistry: my-docker-registry:5000
 
   # remote context can either be a .tar or .tgz file
   context: https://sonny-forge-test.s3-us-west-2.amazonaws.com/multi-stage-app.tgz
@@ -26,3 +26,6 @@ spec:
 
   # do not push image if greater than 50MB
   imageSizeLimit: 52428800
+
+  # push image to an insecure registry
+  insecureRegistry: false

--- a/controllers/containerimagebuild_controller.go
+++ b/controllers/containerimagebuild_controller.go
@@ -71,7 +71,7 @@ func (r *ContainerImageBuildReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 		Memory:           build.Spec.Memory,
 		Timeout:          time.Duration(build.Spec.TimeoutSeconds) * time.Second,
 		SizeLimit:        build.Spec.ImageSizeLimit,
-		InsecureRegistry: true,
+		InsecureRegistry: build.Spec.InsecureRegistry,
 	}
 
 	imageURL, err := r.Builder.Build(ctx, opts)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	go.etcd.io/bbolt v1.3.1-etcd.8
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/grpc v1.23.0
+	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
 	sigs.k8s.io/controller-runtime v0.4.0

--- a/pkg/container/runc/img.go
+++ b/pkg/container/runc/img.go
@@ -49,7 +49,7 @@ func (b *Builder) Build(ctx context.Context, opts config.BuildOptions) (string, 
 		}
 	}
 
-	if err := b.push(ctx, image); err != nil {
+	if err := b.push(ctx, image, opts.InsecureRegistry); err != nil {
 		return "", err
 	}
 	return image, nil
@@ -122,7 +122,7 @@ func (b *Builder) validateImageSize(ctx context.Context, name string, limit uint
 	return nil
 }
 
-func (b *Builder) push(ctx context.Context, image string) error {
+func (b *Builder) push(ctx context.Context, image string, insecure bool) error {
 	sess, sessDialer, err := b.client.Session(ctx, nil)
 	if err != nil {
 		return err
@@ -137,7 +137,7 @@ func (b *Builder) push(ctx context.Context, image string) error {
 	})
 	eg.Go(func() error {
 		defer sess.Close()
-		return b.client.Push(ctx, image, true)
+		return b.client.Push(ctx, image, insecure)
 	})
 	if err := eg.Wait(); err != nil {
 		return err


### PR DESCRIPTION
This works with secure registries that leverage both a real CA and self-signed certificates. Obviously, the latter requires configuring the custom CA on the system where this process runs but that's outside the scope of this project.