### PR TITLE
allow plugin data to be passed through CIB type

### DIFF
--- a/api/v1alpha1/containerimagebuild_types.go
+++ b/api/v1alpha1/containerimagebuild_types.go
@@ -112,6 +112,10 @@ type ContainerImageBuildSpec struct {
 	// an image of any size will be pushed.
 	// +kubebuilder:validation:Optional
 	ImageSizeLimit uint64 `json:"imageSizeLimit"`
+
+	// Provide arbitrary data for use in plugins that extend default capabilities.
+	// +kubebuilder:validation:Optional
+	PluginData map[string]string `json:"pluginData"`
 }
 
 // ContainerImageBuildStatus defines the observed state of ContainerImageBuild

--- a/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
+++ b/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
@@ -74,6 +74,12 @@ spec:
             noCache:
               description: Disable the use of cache layers for a build.
               type: boolean
+            pluginData:
+              additionalProperties:
+                type: string
+              description: Provide arbitrary data for use in plugins that extend default
+                capabilities.
+              type: object
             pushTo:
               description: Push to one or more registries.
               items:

--- a/controllers/containerimagebuild_controller.go
+++ b/controllers/containerimagebuild_controller.go
@@ -92,6 +92,7 @@ func (r *ContainerImageBuildReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 		BuildArgs:      spec.BuildArgs,
 		CpuQuota:       spec.CpuQuota,
 		Memory:         spec.Memory,
+		PluginData:     spec.PluginData,
 		Timeout:        time.Duration(build.Spec.TimeoutSeconds) * time.Second,
 	}
 

--- a/internal/builder/config/config.go
+++ b/internal/builder/config/config.go
@@ -19,6 +19,7 @@ type BuildOptions struct {
 	Timeout        time.Duration
 	Registries     []Registry
 	PushRegistries []string
+	PluginData     map[string]string
 
 	// NOTE: these are not currently used, should we remove them?
 	CpuQuota uint16


### PR DESCRIPTION
To allow for the ability to integrate plugins that need specific data, add a new `pluginData` field to the `containerimagebuild` API.