### PR TITLE
removes OCIImageBuilder dependency on buildkit

### DIFF
--- a/controllers/containerimagebuild_controller.go
+++ b/controllers/containerimagebuild_controller.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
-	bkclient "github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +24,7 @@ import (
 	"github.com/dominodatalab/forge/internal/builder/config"
 	"github.com/dominodatalab/forge/internal/credentials"
 	"github.com/dominodatalab/forge/internal/message"
+	"github.com/dominodatalab/forge/internal/util"
 )
 
 // ContainerImageBuildReconciler reconciles a ContainerImageBuild object
@@ -103,7 +101,7 @@ func (r *ContainerImageBuildReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 	}
 
 	// dispatch build operation
-	imageURLs, err := r.Builder.BuildAndPush(ctx, opts, outputProgressToJSON(&logWriter{log}))
+	imageURLs, err := r.Builder.BuildAndPush(ctx, opts, &util.LogrWriter{Logger: log})
 
 	if err != nil {
 		cause := errors.Cause(errors.Unwrap(err))
@@ -131,23 +129,6 @@ func (r *ContainerImageBuildReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 
 	// reconcile result will ensure this event is not enqueued again
 	return result, nil
-}
-
-type logWriter struct {
-	logger logr.Logger
-}
-
-var _ io.Writer = &logWriter{}
-
-func (l *logWriter) Write(output []byte) (int, error) {
-	l.logger.Info(string(output))
-	return len(output), nil
-}
-
-func outputProgressToJSON(log io.Writer) func(chan *bkclient.SolveStatus) error {
-	return func(statusChannel chan *bkclient.SolveStatus) error {
-		return progressui.DisplaySolveStatus(context.TODO(), "", nil, log, statusChannel)
-	}
 }
 
 func (r *ContainerImageBuildReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -2,16 +2,14 @@ package builder
 
 import (
 	"context"
-
-	bkclient "github.com/moby/buildkit/client"
+	"io"
 
 	"github.com/dominodatalab/forge/internal/builder/config"
 	"github.com/dominodatalab/forge/internal/builder/embedded"
 )
 
-
 type OCIImageBuilder interface {
-	BuildAndPush(context.Context, *config.BuildOptions, func(chan *bkclient.SolveStatus) error) ([]string, error)
+	BuildAndPush(context.Context, *config.BuildOptions, io.Writer) ([]string, error)
 }
 
 func New() (OCIImageBuilder, error) {

--- a/internal/util/logadapter.go
+++ b/internal/util/logadapter.go
@@ -1,0 +1,15 @@
+package util
+
+import "github.com/go-logr/logr"
+
+// logr.Logger writer interface adapter
+// LogrWriter is an
+type LogrWriter struct {
+	Logger logr.Logger
+}
+
+// Write logs a message at the info level.
+func (w *LogrWriter) Write(msg []byte) (int, error) {
+	w.Logger.Info(string(msg))
+	return len(msg), nil
+}

--- a/internal/util/logadapter_test.go
+++ b/internal/util/logadapter_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+type fakeLogger struct{ msg string }
+
+func (l *fakeLogger) Enabled() bool                         { return true }
+func (l *fakeLogger) Info(msg string, kv ...interface{})    { l.msg = msg }
+func (l *fakeLogger) Error(error, string, ...interface{})   {}
+func (l *fakeLogger) V(int) logr.InfoLogger                 { return nil }
+func (l *fakeLogger) WithValues(...interface{}) logr.Logger { return nil }
+func (l *fakeLogger) WithName(string) logr.Logger           { return nil }
+
+func TestLogrWriter_Write(t *testing.T) {
+	l := &fakeLogger{}
+	w := LogrWriter{l}
+	msg := "hello, steve"
+	size, err := w.Write([]byte(msg))
+
+	if err != nil {
+		t.Fatalf("no error was expected: %v", err)
+	}
+
+	if size != len(msg) {
+		t.Fatalf("expected message size %d, got %d", len(msg), size)
+	}
+
+	if l.msg != msg {
+		t.Fatalf("expected logged info message %q, got %q", msg, l.msg)
+	}
+}


### PR DESCRIPTION
if we pass a log writer in instead of a func then we can keep this
generic