### PR TITLE
Leverage errors pkg exclusively

### DIFF
--- a/internal/builder/embedded/bkimage/authprovider.go
+++ b/internal/builder/embedded/bkimage/authprovider.go
@@ -2,10 +2,10 @@ package bkimage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
@@ -24,7 +24,7 @@ func (ap *dynamicAuthProvider) Credentials(ctx context.Context, req *auth.Creden
 
 	username, password, err := ap.credFn(req.Host)
 	if err != nil {
-		return nil, fmt.Errorf("credential fetch failed for %q: %w", req.Host, err)
+		return nil, errors.Wrapf(err, "credential fetch failed for %q", req.Host)
 	}
 
 	return &auth.CredentialsResponse{

--- a/internal/builder/embedded/bkimage/client.go
+++ b/internal/builder/embedded/bkimage/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moby/buildkit/control"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/worker/base"
+	"github.com/pkg/errors"
 
 	"github.com/dominodatalab/forge/internal/builder/embedded/bkimage/types"
 )
@@ -66,7 +67,7 @@ func NewClient(rootDir, backend string, logger logr.Logger) (*Client, error) {
 	client.ResetHostConfigurations()
 
 	if err := client.initDataStores(); err != nil {
-		return nil, fmt.Errorf("initializing data stores failed: %w", err)
+		return nil, errors.Wrap(err, "initializing data stores failed")
 	}
 
 	return client, nil

--- a/internal/builder/embedded/bkimage/controller.go
+++ b/internal/builder/embedded/bkimage/controller.go
@@ -1,7 +1,6 @@
 package bkimage
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/moby/buildkit/cache/remotecache"
@@ -15,37 +14,38 @@ import (
 	"github.com/moby/buildkit/solver/bboltcachestorage"
 	"github.com/moby/buildkit/worker"
 	"github.com/moby/buildkit/worker/base"
+	"github.com/pkg/errors"
 )
 
 func (c *Client) createController() error {
 	// grab the session manager
 	sm, err := c.getSessionManager()
 	if err != nil {
-		return fmt.Errorf("creating session manager failed: %w", err)
+		return errors.Wrap(err, "creating session manager failed")
 	}
 
 	// create the worker opts
 	opt, err := c.createWorkerOpt()
 	if err != nil {
-		return fmt.Errorf("creating worker opt failed: %w", err)
+		return errors.Wrap(err, "creating worker opt failed")
 	}
 
 	// create a new worker
 	w, err := base.NewWorker(opt)
 	if err != nil {
-		return fmt.Errorf("creating worker failed: %w", err)
+		return errors.Wrap(err, "creating worker failed")
 	}
 
 	// create a worker controller and add the worker
 	wc := &worker.Controller{}
 	if err := wc.Add(w); err != nil {
-		return fmt.Errorf("adding worker to worker controller failed: %w", err)
+		return errors.Wrap(err, "adding worker to worker controller failed")
 	}
 
 	// create the cache store
 	cacheStore, err := bboltcachestorage.NewStore(filepath.Join(c.rootDir, "cache.db"))
 	if err != nil {
-		return fmt.Errorf("creating cache store failed: %w", err)
+		return errors.Wrap(err, "creating cache store failed")
 	}
 
 	// create the controller
@@ -69,7 +69,7 @@ func (c *Client) createController() error {
 		Entitlements:              nil,
 	})
 	if err != nil {
-		return fmt.Errorf("creating controller failed: %w", err)
+		return errors.Wrap(err, "creating controller failed")
 	}
 
 	c.controller = controller

--- a/internal/builder/embedded/bkimage/get.go
+++ b/internal/builder/embedded/bkimage/get.go
@@ -2,10 +2,10 @@ package bkimage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
+	"github.com/pkg/errors"
 )
 
 type ListedImage struct {
@@ -21,12 +21,12 @@ func (c *Client) GetImage(ctx context.Context, name string) (*ListedImage, error
 
 	imgObj, err := c.imageStore.Get(ctx, name)
 	if err != nil {
-		return nil, fmt.Errorf("getting image %q from image store failed: %w", name, err)
+		return nil, errors.Wrapf(err, "getting image %q from image store failed", name)
 	}
 
 	size, err := imgObj.Size(ctx, c.contentStore, platforms.Default())
 	if err != nil {
-		return nil, fmt.Errorf("calculating image size of %q failed: %w", name, err)
+		return nil, errors.Wrapf(err, "calculating image size of %q failed", name)
 	}
 
 	return &ListedImage{

--- a/internal/builder/embedded/bkimage/push.go
+++ b/internal/builder/embedded/bkimage/push.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/moby/buildkit/util/push"
+	"github.com/pkg/errors"
 )
 
 func (c *Client) PushImage(ctx context.Context, image string) error {
@@ -16,7 +17,7 @@ func (c *Client) PushImage(ctx context.Context, image string) error {
 	// grab reference to local image object
 	imgObj, err := c.imageStore.Get(ctx, image)
 	if err != nil {
-		return fmt.Errorf("getting image %q from image store failed: %w", image, err)
+		return errors.Wrapf(err, "getting image %q from image store failed", image)
 	}
 
 	sm, err := c.getSessionManager()
@@ -32,7 +33,6 @@ func (c *Client) PushImage(ctx context.Context, image string) error {
 	// see github.com/moby/buildkit@v0.7.1/util/resolver/resolver.go:158 for more details
 	ctx = context.Background()
 
-	// "insecure" param is not used in the following call
-	insecure := false
-	return push.Push(ctx, sm, c.contentStore, imgObj.Target.Digest, image, insecure, c.getRegistryHosts(), false)
+	// NOTE: "insecure" param is not used in the following func call
+	return push.Push(ctx, sm, c.contentStore, imgObj.Target.Digest, image, false, c.getRegistryHosts(), false)
 }

--- a/internal/builder/embedded/bkimage/session.go
+++ b/internal/builder/embedded/bkimage/session.go
@@ -2,11 +2,11 @@ package bkimage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/session/testutil"
+	"github.com/pkg/errors"
 )
 
 const sessionName = "forge"
@@ -24,7 +24,7 @@ func (c *Client) Session(ctx context.Context, localDirs map[string]string) (*ses
 	// create and configure a new session
 	sess, err := session.NewSession(ctx, sessionName, "")
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create session: %w", err)
+		return nil, nil, errors.Wrap(err, "failed to create session")
 	}
 
 	var syncedDirs []filesync.SyncedDir
@@ -50,7 +50,7 @@ func (c *Client) getSessionManager() (*session.Manager, error) {
 		var err error
 		c.sessionManager, err = session.NewManager()
 		if err != nil {
-			return nil, fmt.Errorf("cannot create session manager: %w", err)
+			return nil, errors.Wrap(err, "cannot create session manager")
 		}
 	}
 

--- a/internal/builder/embedded/bkimage/solve.go
+++ b/internal/builder/embedded/bkimage/solve.go
@@ -2,10 +2,10 @@ package bkimage
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	controlapi "github.com/moby/buildkit/api/services/control"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
@@ -32,7 +32,7 @@ func (c *Client) Solve(ctx context.Context, req *controlapi.SolveRequest, ch cha
 
 		_, err := c.controller.Solve(ctx, req)
 		if err != nil {
-			err = fmt.Errorf("failed to solve: %w", err)
+			err = errors.Wrap(err, "failed to solve")
 		}
 		return err
 	})

--- a/internal/builder/embedded/bkimage/stores.go
+++ b/internal/builder/embedded/bkimage/stores.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/snapshots/native"
 	"github.com/containerd/containerd/snapshots/overlay"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
+	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/dominodatalab/forge/internal/builder/embedded/bkimage/types"
@@ -39,7 +40,7 @@ func (c *Client) initDataStores() error {
 		return fmt.Errorf("%s is not a valid snapshotter", c.backend)
 	}
 	if err != nil {
-		return fmt.Errorf("creating %s snapshotter failed: %w", c.backend, err)
+		return errors.Wrapf(err, "creating %s snapshotter failed", c.backend)
 	}
 
 	metadataDB := ctdmetadata.NewDB(db, cs, map[string]snapshots.Snapshotter{

--- a/internal/builder/embedded/bkimage/tag.go
+++ b/internal/builder/embedded/bkimage/tag.go
@@ -2,10 +2,10 @@ package bkimage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
+	"github.com/pkg/errors"
 )
 
 func (c *Client) TagImage(ctx context.Context, src, dest string) error {
@@ -22,7 +22,7 @@ func (c *Client) TagImage(ctx context.Context, src, dest string) error {
 	// grab reference to local image object
 	imgObj, err := c.imageStore.Get(ctx, src)
 	if err != nil {
-		return fmt.Errorf("getting image %q from image store failed: %w", src, err)
+		return errors.Wrapf(err, "getting image %q from image store failed", src)
 	}
 
 	img := images.Image{
@@ -32,11 +32,11 @@ func (c *Client) TagImage(ctx context.Context, src, dest string) error {
 	}
 	if _, err := c.imageStore.Update(ctx, img); err != nil {
 		if !errdefs.IsNotFound(err) {
-			return fmt.Errorf("updating image store with %q failed: %w", dest, err)
+			return errors.Wrapf(err, "updating image store with %q failed", dest)
 		}
 
 		if _, err := c.imageStore.Create(ctx, img); err != nil {
-			return fmt.Errorf("creating image %q in image store failed: %w", dest, err)
+			return errors.Wrapf(err, "creating image %q in image store failed", dest)
 		}
 	}
 

--- a/internal/builder/embedded/bkimage/util.go
+++ b/internal/builder/embedded/bkimage/util.go
@@ -1,16 +1,15 @@
 package bkimage
 
 import (
-	"fmt"
-
 	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
 )
 
 func parseImageName(image string) (string, error) {
 	// parse the image name and tag
 	named, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
-		return "", fmt.Errorf("parsing image name %q failed: %w", image, err)
+		return "", errors.Wrapf(err, "parsing image name %q failed", image)
 	}
 
 	// Add "latest" tag if tag is missing.

--- a/internal/builder/embedded/driver.go
+++ b/internal/builder/embedded/driver.go
@@ -2,7 +2,6 @@ package embedded
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -12,6 +11,7 @@ import (
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dominodatalab/forge/internal/archive"
@@ -29,7 +29,7 @@ type driver struct {
 func NewDriver(logger logr.Logger) (*driver, error) {
 	client, err := bkimage.NewClient(getStateDir(), types.AutoBackend, logger)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create buildkit client: %w", err)
+		return nil, errors.Wrap(err, "cannot create buildkit client")
 	}
 
 	return &driver{


### PR DESCRIPTION
Before we were using `fmt.Errorf("...: %w", err)` and functions in the errors pkg. This change migrates all error wrapping to the latter implementation.