### PR TITLE
changes ContainerImageBuild scope to Namespaced

### DIFF
--- a/api/v1alpha1/containerimagebuild_types.go
+++ b/api/v1alpha1/containerimagebuild_types.go
@@ -143,7 +143,7 @@ func (s *ContainerImageBuildStatus) SetState(state BuildState) {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster,shortName=cib
+// +kubebuilder:resource:scope=Namespaced,shortName=cib
 // +kubebuilder:subresource:status
 
 // ContainerImageBuild is the Schema for the containerimagebuilds API

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,26 +13,51 @@ import (
 	"github.com/dominodatalab/forge/internal/message"
 )
 
+const (
+	description = `Kubernetes-native OCI image builder.
+
+Forge is a Kubernetes controller that builds and pushes OCI-compliant images to one or more distribution registries.
+Communication with the controller is achieved via the ContainerImageBuild CRD defined by the project. Forge will watch
+for these resources, launch an image build using the directives provided therein, and update the resource status with
+relevant information such as build state, errors and the final location(s) of the 
+
+If you need to run preparation steps against a context directory prior to a build, then you can configure one or more
+plugins. This allows users to hook into the build process and add/modify/delete files according to their business
+workflows.
+
+Ideally, state change consumers should set a watch on their ContainerImageBuild resources for updates. When this is not
+possible, this controller can be configured to push state updates to any AMQP message broker.`
+
+	examples = `
+# Watch for ContainerImageBuild resources in your namespace
+forge --namespace <my-ns>
+
+# Publish status updates to an AMQP message broker
+forge --message-broker amqp --amqp-uri amqp://<user>:<pass>@<host>:<port/<path> --amqp-queue <queue-name>
+
+# Leverage one or more plugins for pre-processing a context prior to build
+forge --preparer-plugins-path /plugins/installed/here`
+)
+
 var (
 	debug bool
 
+	namespace            string
 	metricsAddr          string
 	enableLeaderElection bool
-
-	messageBroker string
-	amqpURI       string
-	amqpQueue     string
-
-	preparerPluginsPath string
-
-	brokerOpts *message.Options
+	messageBroker        string
+	amqpURI              string
+	amqpQueue            string
+	preparerPluginsPath  string
+	brokerOpts           *message.Options
 
 	rootCmd = &cobra.Command{
 		Use:     "forge",
-		Short:   "Kubernetes-native OCI image builder.",
+		Long:    description,
+		Example: examples,
 		PreRunE: processBrokerOpts,
 		Run: func(cmd *cobra.Command, args []string) {
-			controllers.StartManager(metricsAddr, enableLeaderElection, brokerOpts, preparerPluginsPath, debug)
+			controllers.StartManager(namespace, metricsAddr, enableLeaderElection, brokerOpts, preparerPluginsPath, debug)
 		},
 	}
 )
@@ -60,6 +85,7 @@ func processBrokerOpts(cmd *cobra.Command, args []string) error {
 func init() {
 	rootCmd.Flags().SortFlags = false
 
+	rootCmd.Flags().StringVar(&namespace, "namespace", "default", "Watch for objects in desired namespace")
 	rootCmd.Flags().StringVar(&metricsAddr, "metrics-addr", ":8080", "Metrics endpoint will bind to this address")
 	rootCmd.Flags().BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	rootCmd.Flags().StringVar(&messageBroker, "message-broker", "", fmt.Sprintf("Publish resource state changes to a message broker (supported values: %v)", message.SupportedBrokers))

--- a/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
+++ b/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
@@ -16,7 +16,7 @@ spec:
     shortNames:
     - cib
     singular: containerimagebuild
-  scope: Cluster
+  scope: Namespaced
   subresources:
     status: {}
   validation:
@@ -89,6 +89,8 @@ spec:
             registries:
               description: Configure one or more registry hosts with special requirements.
               items:
+                description: Registry contains the parameters required to pull and/or
+                  push from an OCI distribution registry.
                 properties:
                   basicAuth:
                     description: Configure basic authentication credentials for a

--- a/config/samples/forge_v1alpha1_containerimagebuild.yaml
+++ b/config/samples/forge_v1alpha1_containerimagebuild.yaml
@@ -2,6 +2,7 @@ apiVersion: forge.dominodatalab.com/v1alpha1
 kind: ContainerImageBuild
 metadata:
   name: example-build
+  namespace: default
 spec:
   # tag is optional (e.g. multi-stage-app:v1.0.0)
   imageName: multi-stage-app

--- a/controllers/containerimagebuild_controller.go
+++ b/controllers/containerimagebuild_controller.go
@@ -42,7 +42,7 @@ type ContainerImageBuildReconciler struct {
 
 func (r *ContainerImageBuildReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
-	log := r.Log.WithValues("containerimagebuild", req.Name)
+	log := r.Log.WithValues("containerimagebuild", req.NamespacedName)
 
 	var result ctrl.Result
 	var build forgev1alpha1.ContainerImageBuild

--- a/controllers/start.go
+++ b/controllers/start.go
@@ -28,7 +28,7 @@ var (
 	setupLog  = ctrl.Log.WithName("setup")
 )
 
-func StartManager(metricsAddr string, enableLeaderElection bool, brokerOpts *message.Options, preparerPluginsPath string, debug bool) {
+func StartManager(namespace string, metricsAddr string, enableLeaderElection bool, brokerOpts *message.Options, preparerPluginsPath string, debug bool) {
 	reexec()
 
 	atom := zap.NewAtomicLevel()
@@ -59,6 +59,7 @@ func StartManager(metricsAddr string, enableLeaderElection bool, brokerOpts *mes
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
 		Port:               9443,
+		Namespace:          namespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "Unable to start manager")


### PR DESCRIPTION
and targets a single NS within the controller so that we can run
multiple instances in a multi-tenant environment. also adds better CLI
documentation.