### PR TITLE
forge: allow secrets to be fetched from any namespace

### DIFF
--- a/controllers/start.go
+++ b/controllers/start.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -91,7 +90,7 @@ func StartManager(namespace string, metricsAddr string, enableLeaderElection boo
 
 	// Create a globally-scoped Kubernetes client. mgr.GetClient() can only
 	// refer to resources in the same-namespace when one is provided.
-	cfg, err := rest.InClusterConfig()
+	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		setupLog.Error(err, "Could not initialize in-cluster Kubernetes config")
 		os.Exit(1)


### PR DESCRIPTION
The namespaced controller-runtime client does not allow cross-NS access
so we instantiate a global client for use with secrets fetch.