### PR TITLE
support memory & CPU constraints

### DIFF
--- a/api/v1alpha1/containerimagebuild_types.go
+++ b/api/v1alpha1/containerimagebuild_types.go
@@ -96,11 +96,9 @@ type ContainerImageBuildSpec struct {
 	// +kubebuilder:validation:Optional
 	NoCache bool `json:"noCache"`
 
-	// Limits build cpu consumption (value should be some value from 0 to 100_000).
+	// Limits build cpu consumption.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Minimum=10000
-	// +kubebuilder:validation:Maximum=100000
-	CpuQuota uint16 `json:"cpuQuota"`
+	CPU string `json:"cpu"`
 
 	// Limits build memory consumption.
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
+++ b/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
@@ -48,12 +48,9 @@ spec:
               description: Build context for the image. This can be a local path or
                 url.
               type: string
-            cpuQuota:
-              description: Limits build cpu consumption (value should be some value
-                from 0 to 100_000).
-              maximum: 100000
-              minimum: 10000
-              type: integer
+            cpu:
+              description: Limits build cpu consumption.
+              type: string
             imageName:
               description: Name used to build an image.
               minLength: 1

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -228,6 +229,26 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 		volumeMounts = append(volumeMounts, *forgeBuildMount)
 	}
 
+	resources := corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{},
+		Requests: corev1.ResourceList{},
+	}
+	if cib.Spec.CpuQuota > 0 {
+		quota := *resource.NewMilliQuantity(int64(cib.Spec.CpuQuota), resource.DecimalSI)
+		resources.Limits["cpu"] = quota
+		resources.Requests["cpu"] = quota
+	}
+
+	if cib.Spec.Memory != "" {
+		memory, err := resource.ParseQuantity(cib.Spec.Memory)
+		if err != nil {
+			return err
+		}
+
+		resources.Limits["memory"] = memory
+		resources.Requests["memory"] = memory
+	}
+
 	// construct final job object
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -254,6 +275,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 							Env:             r.JobConfig.EnvVar,
 							SecurityContext: secCtx,
 							VolumeMounts:    volumeMounts,
+							Resources:       resources,
 						},
 					},
 					Volumes: volumes,

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -78,9 +78,7 @@ func TestContainerImageBuildReconciler_resourceLimits(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.cib.Name, func(t *testing.T) {
-			if err := controller.createJobForBuild(context.TODO(), tc.cib); err != nil {
-				t.Errorf("createJobForBuild() error = %v", err)
-			}
+			require.NoError(t, controller.createJobForBuild(context.TODO(), tc.cib))
 
 			job := &batchv1.Job{}
 			require.NoError(t, controller.Client.Get(context.TODO(), types.NamespacedName{Name: tc.cib.Name}, job))

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -1,0 +1,71 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	forgev1alpha1 "github.com/dominodatalab/forge/api/v1alpha1"
+)
+
+func TestContainerImageBuildReconciler_resourceLimits(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, forgev1alpha1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+
+	fakeClient := fake.NewFakeClientWithScheme(scheme)
+	fakeRecorder := record.NewFakeRecorder(10)
+
+	controller := &ContainerImageBuildReconciler{
+		Log:      log.NullLogger{},
+		Client:   fakeClient,
+		Recorder: fakeRecorder,
+		JobConfig: &BuildJobConfig{
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Scheme: scheme,
+	}
+
+	cib := &forgev1alpha1.ContainerImageBuild{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-cib-resource-quota",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: forgev1alpha1.ContainerImageBuildSpec{
+			CpuQuota: 666,
+			Memory:   "1G",
+		},
+	}
+	if err := controller.createJobForBuild(context.TODO(), cib); err != nil {
+		t.Errorf("createJobForBuild() error = %v", err)
+	}
+
+	job := &batchv1.Job{}
+	require.NoError(t, controller.Client.Get(context.TODO(), types.NamespacedName{Name: "test-cib-resource-quota", Namespace: ""}, job))
+
+	resources := job.Spec.Template.Spec.Containers[0].Resources
+	expected := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			"memory": resource.MustParse("1G"),
+			"cpu":    resource.MustParse("666m"),
+		},
+		Requests: corev1.ResourceList{
+			"memory": resource.MustParse("1G"),
+			"cpu":    resource.MustParse("666m"),
+		},
+	}
+
+	assert.Equal(t, resources, expected)
+}

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -48,8 +48,8 @@ func TestContainerImageBuildReconciler_resourceLimits(t *testing.T) {
 					Name: "test-cib-resource-quota",
 				},
 				Spec: forgev1alpha1.ContainerImageBuildSpec{
-					CpuQuota: 666,
-					Memory:   "1G",
+					CPU:    "666m",
+					Memory: "1G",
 				},
 			},
 			resources: corev1.ResourceRequirements{
@@ -69,8 +69,8 @@ func TestContainerImageBuildReconciler_resourceLimits(t *testing.T) {
 					Name: "test-cib-no-resource-quota",
 				},
 				Spec: forgev1alpha1.ContainerImageBuildSpec{
-					CpuQuota: 0,
-					Memory:   "",
+					CPU:    "",
+					Memory: "",
 				},
 			},
 		},

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -45,8 +45,7 @@ func TestContainerImageBuildReconciler_resourceLimits(t *testing.T) {
 		{
 			cib: &forgev1alpha1.ContainerImageBuild{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cib-resource-quota",
-					CreationTimestamp: metav1.Now(),
+					Name: "test-cib-resource-quota",
 				},
 				Spec: forgev1alpha1.ContainerImageBuildSpec{
 					CpuQuota: 666,
@@ -67,8 +66,7 @@ func TestContainerImageBuildReconciler_resourceLimits(t *testing.T) {
 		{
 			cib: &forgev1alpha1.ContainerImageBuild{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cib-no-resource-quota",
-					CreationTimestamp: metav1.Now(),
+					Name: "test-cib-no-resource-quota",
 				},
 				Spec: forgev1alpha1.ContainerImageBuildSpec{
 					CpuQuota: 0,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,8 +20,4 @@ type BuildOptions struct {
 	Registries     []Registry
 	PushRegistries []string
 	PluginData     map[string]string
-
-	// NOTE: these are not currently used, should we remove them?
-	CpuQuota uint16
-	Memory   string
 }


### PR DESCRIPTION
Currently limits=requests since there is only one field. @sonnysideup would it make more sense for CPUQuota to be a string field too? Feels limiting to keep it an int.