### PR TITLE
support istio for build jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN make static BUILD_FLAGS="$BUILD_FLAGS" && \
 FROM base
 ARG ISTIO_GID=1337
 
-RUN apk add --no-cache fuse3 git pigz
+RUN apk add --no-cache fuse3 git pigz wget
 
 ARG ROOTLESSKIT_VERSION=v0.10.0
 RUN wget -qO - https://github.com/rootless-containers/rootlesskit/releases/download/$ROOTLESSKIT_VERSION/rootlesskit-x86_64.tar.gz | tar -xz -C /usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN make static BUILD_FLAGS="$BUILD_FLAGS" && \
     mv bin/forge /usr/bin/
 
 FROM base
+ARG ISTIO_GID=1337
 
 RUN apk add --no-cache fuse3 git pigz
 
@@ -67,12 +68,12 @@ COPY --from=forge /usr/bin/forge /usr/bin/forge
 
 RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap
 RUN adduser -D -u 1000 user && \
-    addgroup -S -g 1337 istio && \
+    addgroup -S -g $ISTIO_GID istio && \
     addgroup user istio && \
     mkdir -p /run/user/1000 && \
     chown -R user /run/user/1000 /home/user && \
     echo user:100000:65536 | tee /etc/subuid | tee /etc/subgid && \
-    echo user:1337:1 >> /etc/subgid
+    echo user:$ISTIO_GID:1 >> /etc/subgid
 
 USER 1000
 ENV USER user

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,12 @@ COPY --from=forge /usr/bin/forge /usr/bin/forge
 
 RUN chmod u+s /usr/bin/newuidmap /usr/bin/newgidmap
 RUN adduser -D -u 1000 user && \
+    addgroup -S -g 1337 istio && \
+    addgroup user istio && \
     mkdir -p /run/user/1000 && \
     chown -R user /run/user/1000 /home/user && \
-    echo user:100000:65536 | tee /etc/subuid | tee /etc/subgid
+    echo user:100000:65536 | tee /etc/subuid | tee /etc/subgid && \
+    echo user:1337:1 >> /etc/subgid
 
 USER 1000
 ENV USER user

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,6 +70,7 @@ var (
 	buildJobSecurityContextConstraints string
 	buildJobGrantFullPrivilege         bool
 	buildAdvancedConfigFilename        string
+	buildJobIstioSupport               bool
 
 	namespace            string
 	metricsAddr          string
@@ -114,6 +115,7 @@ var (
 					EnvVar:                     advCfg.Env,
 					Volumes:                    advCfg.Volumes,
 					VolumeMounts:               advCfg.VolumeMounts,
+					EnableIstioSupport:         buildJobIstioSupport,
 				},
 			}
 			controllers.StartManager(cfg)
@@ -180,6 +182,7 @@ func init() {
 	rootCmd.Flags().StringVar(&buildJobSecurityContextConstraints, "build-job-security-context-constraints", "", "Run builds jobs using a specified SCC")
 	rootCmd.Flags().BoolVar(&buildJobGrantFullPrivilege, "build-job-full-privilege", false, "Run builds jobs using a privileged root user")
 	rootCmd.Flags().StringVar(&buildAdvancedConfigFilename, "build-job-advanced-config", "", "Add volumes, volume mounts and environment variables to your build jobs using a JSON file")
+	rootCmd.Flags().BoolVar(&buildJobIstioSupport, "build-job-enable-istio-support", false, "Modifies build job resources to support Istio sidecars")
 	rootCmd.Flags().DurationVar(&gcInterval, "gc-interval", 30*time.Minute, "Run ContainerImageBuild cleanup operation according to this interval. Set to 0 to disable")
 	rootCmd.Flags().IntVar(&gcMaxKeepCount, "gc-max-keep", 5, "Delete all ContainerImageBuild resources in a 'finished' state that exceed this count")
 

--- a/controllers/containerimagebuild_controller.go
+++ b/controllers/containerimagebuild_controller.go
@@ -41,6 +41,7 @@ type BuildJobConfig struct {
 	Volumes                    []corev1.Volume
 	VolumeMounts               []corev1.VolumeMount
 	EnvVar                     []corev1.EnvVar
+	EnableIstioSupport         bool
 
 	DynamicVolumes      []corev1.Volume
 	DynamicVolumeMounts []corev1.VolumeMount

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -385,7 +385,10 @@ func (r *ContainerImageBuildReconciler) prepareJobArgs(cib *forgev1alpha1.Contai
 		"build",
 		fmt.Sprintf("--resource=%s", cib.Name),
 		fmt.Sprintf("--enable-layer-caching=%t", r.JobConfig.EnableLayerCaching),
-		fmt.Sprintf("--preparer-plugins-path=%s", r.JobConfig.PreparerPluginPath),
+	}
+
+	if r.JobConfig.PreparerPluginPath != "" {
+		args = append(args, fmt.Sprintf("--preparer-plugins-path=%s", r.JobConfig.PreparerPluginPath))
 	}
 
 	if r.JobConfig.BrokerOpts != nil {

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -403,7 +403,7 @@ func (r *ContainerImageBuildReconciler) prepareJobArgs(cib *forgev1alpha1.Contai
 	}
 
 	if r.JobConfig.EnableIstioSupport {
-		args = append(args, "\n wget -qO- --post-data \"\" http://localhost:15020/quitquitquit")
+		args = append(args, "\nEXIT_CODE=$?; wget -qO- --post-data \"\" http://localhost:15020/quitquitquit; exit $EXIT_CODE")
 	}
 
 	return append([]string{"-c"}, strings.Join(args, " "))

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -403,7 +402,7 @@ func (r *ContainerImageBuildReconciler) prepareJobArgs(cib *forgev1alpha1.Contai
 		args = append([]string{rootlesskitCommand}, args...)
 	}
 
-	if _, found := os.LookupEnv("ISTIO_ENABLED"); found {
+	if r.JobConfig.EnableIstioSupport {
 		args = append(args, "\n wget -qO- --post-data \"\" http://localhost:15020/quitquitquit")
 	}
 


### PR DESCRIPTION
We run (unprivileged) build jobs with an `fsGroup` to ensure that the layer FS has the correct permissions. Without istio/istio#26882, however, Istio will rewrite the fsGroup to 1337 which interferes with running builds unless we also map the group from normal -> user namespace.

In addition, Istio does not have good built-in support for batch jobs (https://github.com/istio/istio/issues/6324) so for right now, there's a new flag to ensure that the sidecar container properly exits when the job is finished.