### PR TITLE
adds the ability to override messaging queue name

### DIFF
--- a/api/v1alpha1/containerimagebuild_types.go
+++ b/api/v1alpha1/containerimagebuild_types.go
@@ -125,6 +125,11 @@ type ContainerImageBuildSpec struct {
 	// Disable export of layer cache when it is enabled.
 	// +kubebuilder:validation:Optional
 	DisableLayerCacheExport bool `json:"disableLayerCacheExport"`
+
+	// Override queue where messages are published when status update messaging is configured. If this value is provided
+	// and the message configuration is missing, then no messages will be published.
+	// +kubebuilder:validation:Optional
+	MessageQueueName string `json:"messageQueueName"`
 }
 
 // ContainerImageBuildStatus defines the observed state of ContainerImageBuild

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ forge --preparer-plugins-path /plugins/installed/here
 forge --enable-layer-caching`
 
 	defaultBuildJobCAImage = "quay.io/domino/forge-init-ca:v1.0.0"
+	defaultMessageQueue    = "forge-status-update"
 )
 
 var (
@@ -189,7 +190,7 @@ func init() {
 	// leveraged by both main and build commands
 	rootCmd.PersistentFlags().StringVar(&messageBroker, "message-broker", "", fmt.Sprintf("Publish resource state changes to a message broker (supported values: %v)", message.SupportedBrokers))
 	rootCmd.PersistentFlags().StringVar(&amqpURI, "amqp-uri", "", "AMQP broker connection URI")
-	rootCmd.PersistentFlags().StringVar(&amqpQueue, "amqp-queue", "", "AMQP broker queue name")
+	rootCmd.PersistentFlags().StringVar(&amqpQueue, "amqp-queue", defaultMessageQueue, "AMQP broker queue name")
 	rootCmd.PersistentFlags().StringVar(&preparerPluginsPath, "preparer-plugins-path", path.Join(config.GetStateDir(), "plugins"), "Path to specific preparer plugins or directory to load them from")
 	rootCmd.PersistentFlags().BoolVar(&enableLayerCaching, "enable-layer-caching", false, "Enable image layer caching")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enabled verbose logging")

--- a/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
+++ b/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
@@ -89,9 +89,9 @@ spec:
               description: Limits build memory consumption.
               type: string
             messageQueueName:
-              description: Publish status update to queue when status update messaging
-                is configured. If the configuration or this value is missing, then
-                no messages will be published.
+              description: Override queue where messages are published when status
+                update messaging is configured. If this value is provided and the
+                message configuration is missing, then no messages will be published.
               type: string
             pluginData:
               additionalProperties:

--- a/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
+++ b/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
@@ -88,6 +88,11 @@ spec:
             memory:
               description: Limits build memory consumption.
               type: string
+            messageQueueName:
+              description: Publish status update to queue when status update messaging
+                is configured. If the configuration or this value is missing, then
+                no messages will be published.
+              type: string
             pluginData:
               additionalProperties:
                 type: string

--- a/config/samples/forge_v1alpha1_containerimagebuild.yaml
+++ b/config/samples/forge_v1alpha1_containerimagebuild.yaml
@@ -47,3 +47,6 @@ spec:
     # registry w/o tls encryption and basic auth
     - server: my-docker-registry:5000
       nonSSL: true
+
+  # override default status update queue name
+  messageQueueName: some-different-queue

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -28,7 +28,7 @@ const (
 	rootlesskitCommand = "rootlesskit"
 	forgeCommand       = "/usr/bin/forge"
 	cloudCredentialsID = "dynamic-cloud-credentials"
-	istioCmdArg        = `\nEXIT_CODE=$?; wget -qO- --post-data "" http://localhost:15020/quitquitquit; exit $EXIT_CODE`
+	istioCmdArg        = "\nEXIT_CODE=$?; wget -qO- --post-data \"\" http://localhost:15020/quitquitquit; exit $EXIT_CODE"
 )
 
 // creates all supporting resources required by build job

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -401,9 +401,9 @@ func (r *ContainerImageBuildReconciler) prepareJobArgs(cib *forgev1alpha1.Contai
 		}
 
 		bs := []string{
+			fmt.Sprintf("--message-broker=%s", opts.Broker),
 			fmt.Sprintf("--amqp-uri=%s", opts.AmqpURI),
 			fmt.Sprintf("--amqp-queue=%s", queueName),
-			fmt.Sprintf("--message-broker=%s", opts.Broker),
 		}
 		args = append(args, bs...)
 	}

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -28,6 +28,7 @@ const (
 	rootlesskitCommand = "rootlesskit"
 	forgeCommand       = "/usr/bin/forge"
 	cloudCredentialsID = "dynamic-cloud-credentials"
+	istioCmdArg        = `\nEXIT_CODE=$?; wget -qO- --post-data "" http://localhost:15020/quitquitquit; exit $EXIT_CODE`
 )
 
 // creates all supporting resources required by build job
@@ -393,10 +394,16 @@ func (r *ContainerImageBuildReconciler) prepareJobArgs(cib *forgev1alpha1.Contai
 
 	if r.JobConfig.BrokerOpts != nil {
 		opts := r.JobConfig.BrokerOpts
+
+		queueName := opts.AmqpQueue
+		if cib.Spec.MessageQueueName != "" {
+			queueName = cib.Spec.MessageQueueName
+		}
+
 		bs := []string{
-			fmt.Sprintf("--message-broker=%s", opts.Broker),
-			fmt.Sprintf("--amqp-queue=%s", opts.AmqpQueue),
 			fmt.Sprintf("--amqp-uri=%s", opts.AmqpURI),
+			fmt.Sprintf("--amqp-queue=%s", queueName),
+			fmt.Sprintf("--message-broker=%s", opts.Broker),
 		}
 		args = append(args, bs...)
 	}
@@ -406,7 +413,7 @@ func (r *ContainerImageBuildReconciler) prepareJobArgs(cib *forgev1alpha1.Contai
 	}
 
 	if r.JobConfig.EnableIstioSupport {
-		args = append(args, "\nEXIT_CODE=$?; wget -qO- --post-data \"\" http://localhost:15020/quitquitquit; exit $EXIT_CODE")
+		args = append(args, istioCmdArg)
 	}
 
 	return append([]string{"-c"}, strings.Join(args, " "))

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,7 +116,7 @@ func TestContainerImageBuildReconciler_prepareJobArgs(t *testing.T) {
 				AmqpURI:   "amqp://uri:5672",
 				AmqpQueue: "my-queue",
 			}},
-			want: "rootlesskit /usr/bin/forge build --resource=test-cib --enable-layer-caching=false --message-broker=my-broker --amqp-queue=my-queue --amqp-uri=amqp://uri:5672",
+			want: "rootlesskit /usr/bin/forge build --resource=test-cib --enable-layer-caching=false --message-broker=my-broker --amqp-uri=amqp://uri:5672 --amqp-queue=my-queue",
 		},
 		{
 			name:      "preparer plugins path",
@@ -130,11 +129,11 @@ func TestContainerImageBuildReconciler_prepareJobArgs(t *testing.T) {
 			r := &ContainerImageBuildReconciler{
 				JobConfig: tt.jobConfig,
 			}
-			if got := r.prepareJobArgs(&forgev1alpha1.ContainerImageBuild{
+			got := r.prepareJobArgs(&forgev1alpha1.ContainerImageBuild{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-cib"},
-			}); !reflect.DeepEqual(got, []string{"-c", tt.want}) {
-				t.Errorf("prepareJobArgs() = %v, want %v", got, tt.want)
-			}
+			})
+
+			assert.Equal(t, []string{"-c", tt.want}, got)
 		})
 	}
 }

--- a/internal/cloud/registry/ecr/ecr_test.go
+++ b/internal/cloud/registry/ecr/ecr_test.go
@@ -134,8 +134,8 @@ func TestLoadAuths(t *testing.T) {
 type mockECRClient struct {
 	ecriface.ClientAPI
 	inValid func(input *ecr.GetAuthorizationTokenInput) // validate input
-	out     *ecr.GetAuthorizationTokenOutput // mock output
-	err     error // mock error
+	out     *ecr.GetAuthorizationTokenOutput            // mock output
+	err     error                                       // mock error
 }
 
 func (m *mockECRClient) GetAuthorizationTokenRequest(input *ecr.GetAuthorizationTokenInput) ecr.GetAuthorizationTokenRequest {


### PR DESCRIPTION
## Changes

- sets default value for `--amqp-queue`
- allows override of queue name via ContainerImageBuild resource
- adds other minor refactors

## Rationale

From a usability standpoint, have a default queue with override capabilities feels nice. _If you use a single queue, set it once and forget about it, otherwise override when/where necessary._ Furthermore, I'd like to run messaging options validation at both levels, ergo, setting a default queue name allows the user to input the broker/endpoint (optionally a queue name) and we can validate the options prior to starting the controller. This same validation is done when the build job is launched and a minor change to the controller resource logic will apply the override queue name iff present.