### PR TITLE
allow image pull secrets for build job to be specified

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,7 @@ var (
 
 	buildJobImage                      string
 	buildJobCAImage                    string
+	buildJobImagePullSecret            string
 	buildJobLabels                     map[string]string
 	buildJobAnnotations                map[string]string
 	buildJobNodeSelector               map[string]string
@@ -103,6 +104,7 @@ var (
 				JobConfig: &controllers.BuildJobConfig{
 					Image:                      buildJobImage,
 					CAImage:                    buildJobCAImage,
+					ImagePullSecret:            buildJobImagePullSecret,
 					CustomCASecret:             buildJobCustomCASecret,
 					PreparerPluginPath:         preparerPluginsPath,
 					Labels:                     buildJobLabels,
@@ -175,6 +177,7 @@ func init() {
 
 	rootCmd.Flags().StringVar(&buildJobImage, "build-job-image", buildJobImage, "Image used to launch build jobs. This typically should be the same as the controller.")
 	rootCmd.Flags().StringVar(&buildJobCAImage, "build-job-ca-image", defaultBuildJobCAImage, "Image used to initialize SSL certificates using a custom CA. You should not have to override this.")
+	rootCmd.Flags().StringVar(&buildJobImagePullSecret, "build-job-image-pull-secret", "", "Pull secret used to fetch build job images.")
 	rootCmd.Flags().StringToStringVar(&buildJobLabels, "build-job-labels", nil, "Additional labels added to build job pods")
 	rootCmd.Flags().StringToStringVar(&buildJobAnnotations, "build-job-annotations", nil, "Additional annotations added to build job pods")
 	rootCmd.Flags().StringToStringVar(&buildJobNodeSelector, "build-job-node-selector", nil, "Target specific nodes when launching build job pods")

--- a/controllers/containerimagebuild_controller.go
+++ b/controllers/containerimagebuild_controller.go
@@ -28,6 +28,7 @@ const gcDeleteOpt = client.PropagationPolicy(metav1.DeletePropagationForeground)
 type BuildJobConfig struct {
 	Image                      string
 	CAImage                    string
+	ImagePullSecret            string
 	CustomCASecret             string
 	PreparerPluginPath         string
 	Labels                     map[string]string

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -341,6 +341,11 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 		resources.Requests["memory"] = memory
 	}
 
+	var imagePullSecrets []corev1.LocalObjectReference
+	if r.JobConfig.ImagePullSecret != "" {
+		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: r.JobConfig.ImagePullSecret})
+	}
+
 	// construct final job object
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -358,6 +363,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 					RestartPolicy:      corev1.RestartPolicyNever,
 					InitContainers:     initContainers,
 					SecurityContext:    podSecCtx,
+					ImagePullSecrets:   imagePullSecrets,
 					Containers: []corev1.Container{
 						{
 							Name:            "forge-build",


### PR DESCRIPTION
Images used in the build may come from a private registry and need a specified pull secret.