### PR TITLE
Set ImagePullPolicy

### DIFF
--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -368,6 +368,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 						{
 							Name:            "forge-build",
 							Image:           r.JobConfig.Image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"/bin/sh"},
 							Args:            r.prepareJobArgs(cib),
 							Env:             r.JobConfig.EnvVar,


### PR DESCRIPTION
Sets image pull policy for the build container to `PullIfNotPresent` so that it won't be pulled on every build.

If required, another PR can introduce an override for dev mode to set it to Always. That won't be required if a different tag is used for each image built in dev mode.