### PR TITLE
Add init container name property

### DIFF
--- a/api/v1alpha1/containerimagebuild_types.go
+++ b/api/v1alpha1/containerimagebuild_types.go
@@ -85,6 +85,10 @@ type EnvVar struct {
 
 // InitContainer specifies a container that will run before the build container.
 type InitContainer struct {
+	// Name of the init container.
+	// +kubebuilder:validation:MinLength=1
+	Name string `json:"name"`
+
 	// Docker image name.
 	// +kubebuilder:validation:MinLength=1
 	Image string `json:"image"`

--- a/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
+++ b/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
@@ -130,8 +130,13 @@ spec:
                     description: Docker image name.
                     minLength: 1
                     type: string
+                  name:
+                    description: Name of the init container.
+                    minLength: 1
+                    type: string
                 required:
                 - image
+                - name
                 type: object
               type: array
             labels:

--- a/config/samples/init-container-sample.yaml
+++ b/config/samples/init-container-sample.yaml
@@ -14,7 +14,8 @@ spec:
         secretName: docker-registry-auth
         secretNamespace: default
   initContainers:
-    - image: "busybox"
+    - name: "test-init"
+      image: "busybox"
       command: ["/bin/sh"]
       args:
         - "-c"

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -334,7 +334,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 	}
 
 	// include any init containers provided in the custom resource
-	for order, initContainer := range cib.Spec.InitContainers {
+	for _, initContainer := range cib.Spec.InitContainers {
 		var env []corev1.EnvVar
 		for _, envVar := range initContainer.Env {
 			env = append(env, corev1.EnvVar{
@@ -343,7 +343,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 			})
 		}
 		initContainers = append(initContainers, corev1.Container{
-			Name:    fmt.Sprintf("cib-init-%v", order),
+			Name:    initContainer.Name,
 			Image:   initContainer.Image,
 			Command: initContainer.Command,
 			Args:    initContainer.Args,

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -117,6 +117,7 @@ func TestContainerImageBuildReconciler_initContainers(t *testing.T) {
 		Spec: forgev1alpha1.ContainerImageBuildSpec{
 			InitContainers: []forgev1alpha1.InitContainer{
 				{
+					Name:    "init0",
 					Image:   "init-container-0-image",
 					Command: []string{"command0"},
 					Args:    []string{"arg0.0", "arg0.1"},
@@ -132,6 +133,7 @@ func TestContainerImageBuildReconciler_initContainers(t *testing.T) {
 					},
 				},
 				{
+					Name:    "init1",
 					Image:   "init-container-1-image",
 					Command: []string{"command1"},
 					Args:    []string{"arg1.0", "arg1.1"},
@@ -159,7 +161,7 @@ func TestContainerImageBuildReconciler_initContainers(t *testing.T) {
 		MountPath: "/mnt/build",
 	}
 	expected0 := corev1.Container{
-		Name:    "cib-init-0",
+		Name:    "init0",
 		Image:   "init-container-0-image",
 		Command: []string{"command0"},
 		Args:    []string{"arg0.0", "arg0.1"},
@@ -180,7 +182,7 @@ func TestContainerImageBuildReconciler_initContainers(t *testing.T) {
 		VolumeMounts: []corev1.VolumeMount{expectedVolumeMount},
 	}
 	expected1 := corev1.Container{
-		Name:    "cib-init-1",
+		Name:    "init1",
 		Image:   "init-container-1-image",
 		Command: []string{"command1"},
 		Args:    []string{"arg1.0", "arg1.1"},

--- a/e2e/builds/init_container.yaml
+++ b/e2e/builds/init_container.yaml
@@ -15,7 +15,8 @@ spec:
         username: marge
         password: simpson
   initContainers:
-    - image: "busybox"
+    - name: "test-init"
+      image: "busybox"
       command: ["/bin/sh"]
       args:
         - "-c"


### PR DESCRIPTION
Adds a "name" property to the init container spec on the custom resource.

The auto-generated names proved to be too cumbersome.