### PR TITLE
local cmd change to address forge build tolerations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ const (
 Forge is a Kubernetes controller that builds and pushes OCI-compliant images to one or more distribution registries.
 Communication with the controller is achieved via the ContainerImageBuild CRD defined by the project. Forge will watch
 for these resources, launch an image build using the directives provided therein, and update the resource status with
-relevant information such as build state, errors and the final location(s) of the 
+relevant information such as build state, errors and the final location(s) of the
 
 If you need to run preparation steps against a context directory prior to a build, then you can configure one or more
 plugins. This allows users to hook into the build process and add/modify/delete files according to their business
@@ -67,6 +67,7 @@ var (
 	buildJobLabels                     map[string]string
 	buildJobAnnotations                map[string]string
 	buildJobNodeSelector               map[string]string
+  buildJobTolerationKey              string
 	buildJobCustomCASecret             string
 	buildJobPodSecurityPolicy          string
 	buildJobSecurityContextConstraints string
@@ -108,6 +109,7 @@ var (
 					CustomCASecret:             buildJobCustomCASecret,
 					PreparerPluginPath:         preparerPluginsPath,
 					Labels:                     buildJobLabels,
+          TolerationKey:              buildJobTolerationKey,
 					Annotations:                buildJobAnnotations,
 					NodeSelector:               buildJobNodeSelector,
 					PodSecurityPolicy:          buildJobPodSecurityPolicy,
@@ -180,6 +182,7 @@ func init() {
 	rootCmd.Flags().StringVar(&buildJobImagePullSecret, "build-job-image-pull-secret", "", "Pull secret used to fetch build job images.")
 	rootCmd.Flags().StringToStringVar(&buildJobLabels, "build-job-labels", nil, "Additional labels added to build job pods")
 	rootCmd.Flags().StringToStringVar(&buildJobAnnotations, "build-job-annotations", nil, "Additional annotations added to build job pods")
+  rootCmd.Flags().StringToStringVar(&buildJobTolerationKey, "build-job-toleration-key", nil, "Toleration key added to build job pods with 'exists' operator")
 	rootCmd.Flags().StringToStringVar(&buildJobNodeSelector, "build-job-node-selector", nil, "Target specific nodes when launching build job pods")
 	rootCmd.Flags().StringVar(&buildJobCustomCASecret, "build-job-custom-ca", "", "Secret container custom CA certificates for distribution registries")
 	rootCmd.Flags().StringVar(&buildJobPodSecurityPolicy, "build-job-pod-security-policy", "", "Run builds jobs using a specified PSP")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -182,7 +182,7 @@ func init() {
 	rootCmd.Flags().StringVar(&buildJobImagePullSecret, "build-job-image-pull-secret", "", "Pull secret used to fetch build job images.")
 	rootCmd.Flags().StringToStringVar(&buildJobLabels, "build-job-labels", nil, "Additional labels added to build job pods")
 	rootCmd.Flags().StringToStringVar(&buildJobAnnotations, "build-job-annotations", nil, "Additional annotations added to build job pods")
-	rootCmd.Flags().StringToStringVar(&buildJobTolerationKey, "build-job-toleration-key", nil, "Toleration key added to build job pods with 'exists' operator")
+	rootCmd.Flags().StringVar(&buildJobTolerationKey, "build-job-toleration-key", nil, "Toleration key added to build job pods with 'exists' operator")
 	rootCmd.Flags().StringToStringVar(&buildJobNodeSelector, "build-job-node-selector", nil, "Target specific nodes when launching build job pods")
 	rootCmd.Flags().StringVar(&buildJobCustomCASecret, "build-job-custom-ca", "", "Secret container custom CA certificates for distribution registries")
 	rootCmd.Flags().StringVar(&buildJobPodSecurityPolicy, "build-job-pod-security-policy", "", "Run builds jobs using a specified PSP")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,7 +67,7 @@ var (
 	buildJobLabels                     map[string]string
 	buildJobAnnotations                map[string]string
 	buildJobNodeSelector               map[string]string
-  buildJobTolerationKey              string
+	buildJobTolerationKey              string
 	buildJobCustomCASecret             string
 	buildJobPodSecurityPolicy          string
 	buildJobSecurityContextConstraints string
@@ -109,7 +109,7 @@ var (
 					CustomCASecret:             buildJobCustomCASecret,
 					PreparerPluginPath:         preparerPluginsPath,
 					Labels:                     buildJobLabels,
-          TolerationKey:              buildJobTolerationKey,
+					TolerationKey:              buildJobTolerationKey,
 					Annotations:                buildJobAnnotations,
 					NodeSelector:               buildJobNodeSelector,
 					PodSecurityPolicy:          buildJobPodSecurityPolicy,
@@ -182,7 +182,7 @@ func init() {
 	rootCmd.Flags().StringVar(&buildJobImagePullSecret, "build-job-image-pull-secret", "", "Pull secret used to fetch build job images.")
 	rootCmd.Flags().StringToStringVar(&buildJobLabels, "build-job-labels", nil, "Additional labels added to build job pods")
 	rootCmd.Flags().StringToStringVar(&buildJobAnnotations, "build-job-annotations", nil, "Additional annotations added to build job pods")
-  rootCmd.Flags().StringToStringVar(&buildJobTolerationKey, "build-job-toleration-key", nil, "Toleration key added to build job pods with 'exists' operator")
+	rootCmd.Flags().StringToStringVar(&buildJobTolerationKey, "build-job-toleration-key", nil, "Toleration key added to build job pods with 'exists' operator")
 	rootCmd.Flags().StringToStringVar(&buildJobNodeSelector, "build-job-node-selector", nil, "Target specific nodes when launching build job pods")
 	rootCmd.Flags().StringVar(&buildJobCustomCASecret, "build-job-custom-ca", "", "Secret container custom CA certificates for distribution registries")
 	rootCmd.Flags().StringVar(&buildJobPodSecurityPolicy, "build-job-pod-security-policy", "", "Run builds jobs using a specified PSP")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -182,7 +182,7 @@ func init() {
 	rootCmd.Flags().StringVar(&buildJobImagePullSecret, "build-job-image-pull-secret", "", "Pull secret used to fetch build job images.")
 	rootCmd.Flags().StringToStringVar(&buildJobLabels, "build-job-labels", nil, "Additional labels added to build job pods")
 	rootCmd.Flags().StringToStringVar(&buildJobAnnotations, "build-job-annotations", nil, "Additional annotations added to build job pods")
-	rootCmd.Flags().StringVar(&buildJobTolerationKey, "build-job-toleration-key", nil, "Toleration key added to build job pods with 'exists' operator")
+	rootCmd.Flags().StringVar(&buildJobTolerationKey, "build-job-toleration-key", "", "Toleration key added to build job pods with 'exists' operator")
 	rootCmd.Flags().StringToStringVar(&buildJobNodeSelector, "build-job-node-selector", nil, "Target specific nodes when launching build job pods")
 	rootCmd.Flags().StringVar(&buildJobCustomCASecret, "build-job-custom-ca", "", "Secret container custom CA certificates for distribution registries")
 	rootCmd.Flags().StringVar(&buildJobPodSecurityPolicy, "build-job-pod-security-policy", "", "Run builds jobs using a specified PSP")

--- a/controllers/containerimagebuild_controller.go
+++ b/controllers/containerimagebuild_controller.go
@@ -34,6 +34,7 @@ type BuildJobConfig struct {
 	Labels                     map[string]string
 	Annotations                map[string]string
 	NodeSelector               map[string]string
+  TolerationKey              string
 	GrantFullPrivilege         bool
 	EnableLayerCaching         bool
 	PodSecurityPolicy          string

--- a/controllers/containerimagebuild_controller.go
+++ b/controllers/containerimagebuild_controller.go
@@ -34,7 +34,7 @@ type BuildJobConfig struct {
 	Labels                     map[string]string
 	Annotations                map[string]string
 	NodeSelector               map[string]string
-  TolerationKey              string
+	TolerationKey              string
 	GrantFullPrivilege         bool
 	EnableLayerCaching         bool
 	PodSecurityPolicy          string

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -417,7 +417,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 
 	if r.JobConfig.ImagePullSecret != "" {
 		var tolerations []corev1.Toleration
-    var toleration = corev1.Toleration{
+		var toleration = corev1.Toleration{
 			Effect: "NoSchedule",
 			Key: r.JobConfig.TolerationKey,
 			Operator: "Exists",

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -415,14 +415,14 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 		},
 	}
 
-  if r.JobConfig.ImagePullSecret != "" {
-    var toleration = corev1.Toleration{
+	if r.JobConfig.ImagePullSecret != "" {
+		var toleration = corev1.Toleration{
 			Effect: "NoSchedule",
 			Key: r.JobConfig.TolerationKey,
-      Operator: "Exists",
+			Operator: "Exists",
 		}
-    job.Spec.Tolerations = toleration
-  }
+		job.Spec.Tolerations = toleration
+	}
 
 	return r.withOwnedResource(ctx, cib, job)
 }

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -404,7 +404,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 					InitContainers:     initContainers,
 					SecurityContext:    podSecCtx,
 					ImagePullSecrets:   imagePullSecrets,
-					Tolerations:				tolerations,
+					Tolerations:	    tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:            "forge-build",

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -416,13 +416,13 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 	}
 
 	if r.JobConfig.ImagePullSecret != "" {
-		var toleration []corev1.Toleration
-    toleration[0] = corev1.Toleration{
+		var tolerations []corev1.Toleration
+    toleration = corev1.Toleration{
 			Effect: "NoSchedule",
 			Key: r.JobConfig.TolerationKey,
 			Operator: "Exists",
 		}
-		job.Spec.Template.Spec.Tolerations = toleration
+		job.Spec.Template.Spec.Tolerations = append(tolerations, toleration)
 	}
 
 	return r.withOwnedResource(ctx, cib, job)

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -416,7 +416,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 	}
 
 	if r.JobConfig.ImagePullSecret != "" {
-		var toleration [1]corev1.Toleration
+		var toleration []corev1.Toleration
     toleration[0] = corev1.Toleration{
 			Effect: "NoSchedule",
 			Key: r.JobConfig.TolerationKey,

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -378,7 +378,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: r.JobConfig.ImagePullSecret})
 	}
 
-	// construct final job object
+	// construct job object
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cib.Name,
@@ -414,6 +414,15 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 			},
 		},
 	}
+
+  if r.JobConfig.ImagePullSecret != "" {
+    var toleration = corev1.Toleration{
+			Effect: "NoSchedule",
+			Key: r.JobConfig.TolerationKey,
+      Operator: "Exists",
+		}
+    job.Spec.Tolerations = toleration
+  }
 
 	return r.withOwnedResource(ctx, cib, job)
 }

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -416,7 +416,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 	}
 
 	if r.JobConfig.ImagePullSecret != "" {
-		var toleration = [1]corev1.Toleration
+		var toleration [1]corev1.Toleration
     toleration[0] = corev1.Toleration{
 			Effect: "NoSchedule",
 			Key: r.JobConfig.TolerationKey,

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -380,11 +380,10 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 
 	var tolerations []corev1.Toleration
 	if r.JobConfig.TolerationKey != "" {
-		var toleration = corev1.Toleration{
+		tolerations = append(tolerations,  corev1.Toleration{
 			Key: r.JobConfig.TolerationKey,
 			Operator: "Exists",
-		}
-		tolerations = append(tolerations, toleration)
+		})
 	}
 
 	// construct job object

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -421,7 +421,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 			Key: r.JobConfig.TolerationKey,
 			Operator: "Exists",
 		}
-		job.Spec.Tolerations = toleration
+		job.Spec.Template.Spec.Tolerations = toleration
 	}
 
 	return r.withOwnedResource(ctx, cib, job)

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -378,7 +378,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: r.JobConfig.ImagePullSecret})
 	}
 
-  var tolerations []corev1.Toleration
+	var tolerations []corev1.Toleration
 	if r.JobConfig.TolerationKey != "" {
 		var toleration = corev1.Toleration{
 			Key: r.JobConfig.TolerationKey,
@@ -405,7 +405,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 					InitContainers:     initContainers,
 					SecurityContext:    podSecCtx,
 					ImagePullSecrets:   imagePullSecrets,
-          Tolerations:				tolerations,
+					Tolerations:				tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:            "forge-build",

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -415,7 +415,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 		},
 	}
 
-	if r.JobConfig.ImagePullSecret != "" {
+	if r.JobConfig.TolerationKey != "" {
 		var tolerations []corev1.Toleration
 		var toleration = corev1.Toleration{
 			Effect: "NoSchedule",

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -416,7 +416,8 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 	}
 
 	if r.JobConfig.ImagePullSecret != "" {
-		var toleration = corev1.Toleration{
+		var toleration = [1]corev1.Toleration
+    toleration[0] = corev1.Toleration{
 			Effect: "NoSchedule",
 			Key: r.JobConfig.TolerationKey,
 			Operator: "Exists",

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -417,7 +417,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 
 	if r.JobConfig.ImagePullSecret != "" {
 		var tolerations []corev1.Toleration
-    toleration = corev1.Toleration{
+    var toleration = corev1.Toleration{
 			Effect: "NoSchedule",
 			Key: r.JobConfig.TolerationKey,
 			Operator: "Exists",

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -207,6 +207,22 @@ func TestContainerImageBuildReconciler_initContainers(t *testing.T) {
 	assert.Contains(t, job.Spec.Template.Spec.InitContainers, expected1)
 }
 
+func TestContainerImageBuildReconciler_tolerations(t *testing.T) {
+	controller := makeController(t)
+	cib := &forgev1alpha1.ContainerImageBuild{}
+	r := &ContainerImageBuildReconciler{
+		JobConfig: &BuildJobConfig{TolerationKey: "toleration1"},
+	}
+	require.NoError(t, controller.createJobForBuild(context.Background(), cib))
+	job := &batchv1.Job{}
+	require.NoError(t, controller.Client.Get(context.Background(), types.NamespacedName{Name: cib.Name}, job))
+	expected := corev1.Toleration{
+			Key: "toleration1",
+			Operator: "Exists",
+	}
+	assert.Equal(t, job.Spec.Template.Spec.Tolerations, expected)
+}
+
 func TestContainerImageBuildReconciler_prepareJobArgs(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -213,14 +213,14 @@ func TestContainerImageBuildReconciler_tolerations(t *testing.T) {
 	r := &ContainerImageBuildReconciler{
 		JobConfig: &BuildJobConfig{TolerationKey: "toleration1"},
 	}
-	require.NoError(t, controller.createJobForBuild(context.Background(), cib))
+	require.NoError(t, r.createJobForBuild(context.Background(), cib))
 	job := &batchv1.Job{}
 	require.NoError(t, controller.Client.Get(context.Background(), types.NamespacedName{Name: cib.Name}, job))
 	expected := corev1.Toleration{
 			Key: "toleration1",
 			Operator: "Exists",
 	}
-	assert.Equal(t, job.Spec.Template.Spec.Tolerations, expected)
+	assert.Contains(t, job.Spec.Template.Spec.Tolerations, expected)
 }
 
 func TestContainerImageBuildReconciler_prepareJobArgs(t *testing.T) {

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -210,10 +210,8 @@ func TestContainerImageBuildReconciler_initContainers(t *testing.T) {
 func TestContainerImageBuildReconciler_tolerations(t *testing.T) {
 	controller := makeController(t)
 	cib := &forgev1alpha1.ContainerImageBuild{}
-	r := &ContainerImageBuildReconciler{
-		JobConfig: &BuildJobConfig{TolerationKey: "toleration1"},
-	}
-	require.NoError(t, r.createJobForBuild(context.Background(), cib))
+	controller.JobConfig.TolerationKey = "toleration1"
+	require.NoError(t, controller.createJobForBuild(context.Background(), cib))
 	job := &batchv1.Job{}
 	require.NoError(t, controller.Client.Get(context.Background(), types.NamespacedName{Name: cib.Name}, job))
 	expected := corev1.Toleration{


### PR DESCRIPTION
One customer is the major driver for wanting custom tolerations on Forge builds, and they don't strictly need it to be dynamically controlled via the central config, so I figured I could add a local solution here pretty quickly.

This adds a cmd arg for Forge that specifies a taint key to always tolerate for Forge builds. By default no toleration is set.

If this is a suitable approach I will follow this PR with a change to the Forge chart to add this to the values file and deployment template.

**I tested this as follows:**

1. I configured my cluster with a single build node with the following taint:

   `Taints:             dedicated=true:NoSchedule`

2. I deployed this branch with the following default args to forge:

   ```
         - args:
           - --namespace
           - istionj278040-compute
           - --metrics-addr
           - :8080
           - --build-job-image
           - quay.io/domino/forge:v0.3.5-replicator
           - --build-job-advanced-config
           - /etc/config/advanced-config.json
           - --build-job-enable-istio-support
           - --enable-leader-election
           - --enable-layer-caching
           - --build-job-labels
           - docker-registry-client=true
           - --build-job-labels
           - rabbitmq-ha-client=true
           - --build-job-toleration-key
           - dedicated
           - --build-job-annotations
           - traffic.sidecar.istio.io/excludeOutboundPorts=5000
           - --build-job-node-selector
           - dominodatalab.com/domino-node=true
           - --build-job-node-selector
           - dominodatalab.com/node-pool=default
           - --build-job-ca-image
           - quay.io/domino/forge-init-ca:master.dc9f2d2d822bd2ac59d567d816a9fd91904afeec
           - --build-job-custom-ca
           - domino-ca
           - --build-job-image-pull-secret
           - domino-quay-repos
           - --build-job-pod-security-policy
           - domino-istionj278040-compute-forge
           - --preparer-plugins-path
           - /usr/local/share/forge/plugins/forge-replicator-plugin
           - --message-broker
           - amqp
           - --amqp-uri
           - amqp://rabbitmq:XXXXXXX@rabbitmq-ha.istionj278040-platform:5672
           - --amqp-queue
           - containerimagebuilds.status-update
   ```

3. Creating builds through Forge with these args results in expected failure to schedule due to the taint:

   ```
   $ kubectl describe po domino-build-609ac12f39452526f7fd4445-8r6wb -n istionj278040-compute
   Name:               domino-build-609ac12f39452526f7fd4445-8r6wb
   
   ... snip ...
   
   Node-Selectors:  dominodatalab.com/domino-node=true
                    dominodatalab.com/node-pool=default
   Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                    node.kubernetes.io/unreachable:NoExecute for 300s
   Events:
     Type     Reason             Age        From                Message
     ----     ------             ----       ----                -------
     Warning  FailedScheduling   <unknown>                      0/3 nodes are available: 1 Insufficient cpu, 1 Insufficient memory, 1 node(s) didn't match node selector, 1 node(s) had taint {dedicated: true}, that the pod didn't tolerate.
   ```

4. I then edited the Forge deployment to add the following arg to Forge:

   ```
   - --build-job-toleration-key
   - dedicated
   ```

5. After the new Forge pod came up, I deployed a new build, which received the expected toleration and was scheduled:

   ```
   $ kubectl describe po domino-build-609ac26339452526f7fd4448-r2vj8 -n istionj278040-compute
   Name:               domino-build-609ac26339452526f7fd4448-r2vj8
   
   ... snip ...
   
   Node-Selectors:  dominodatalab.com/domino-node=true
                    dominodatalab.com/node-pool=default
   Tolerations:     dedicated:NoSchedule
                    node.kubernetes.io/not-ready:NoExecute for 300s
                    node.kubernetes.io/unreachable:NoExecute for 300s
   Events:
     Type     Reason                  Age        From                                                Message
     ----     ------                  ----       ----                                                -------
     Normal   Scheduled               <unknown>                                                      Successfully assigned istionj278040-compute/domino-build-609ac26339452526f7fd4448-r2vj8 to ip-10-0-49-155.us-west-2.compute.internal
   ```

cc @steved @sonnysideup