### PR TITLE
allow setting generic resources on image build resources

### DIFF
--- a/api/v1alpha1/containerimagebuild_types.go
+++ b/api/v1alpha1/containerimagebuild_types.go
@@ -133,6 +133,10 @@ type ContainerImageBuildSpec struct {
 	// +kubebuilder:validation:Optional
 	Memory string `json:"memory"`
 
+	// Resources are the requests and limits applied to image builds.
+	// +kubebuilder:validation:Optional
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
 	// Optional deadline in seconds for image build to complete.
 	// +kubebuilder:validation:Optional
 	TimeoutSeconds uint16 `json:"timeoutSeconds"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -108,6 +108,7 @@ func (in *ContainerImageBuildSpec) DeepCopyInto(out *ContainerImageBuildSpec) {
 			(*out)[key] = val
 		}
 	}
+	in.Resources.DeepCopyInto(&out.Resources)
 	if in.PluginData != nil {
 		in, out := &in.PluginData, &out.PluginData
 		*out = make(map[string]string, len(*in))

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -21,7 +21,6 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - crd-apply
-      terminationGracePeriodSeconds: 10
       containers:
         - name: controller
           image: quay.io/domino/forge:latest

--- a/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
+++ b/config/crd/bases/forge.dominodatalab.com_containerimagebuilds.yaml
@@ -289,6 +289,25 @@ spec:
                 - server
                 type: object
               type: array
+            resources:
+              description: Resources are the requests and limits applied to image
+                builds.
+              properties:
+                limits:
+                  additionalProperties:
+                    type: string
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    type: string
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
             timeoutSeconds:
               description: Optional deadline in seconds for image build to complete.
               type: integer

--- a/controllers/containerimagebuild_resources.go
+++ b/controllers/containerimagebuild_resources.go
@@ -349,10 +349,16 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 		})
 	}
 
-	resources := corev1.ResourceRequirements{
-		Limits:   corev1.ResourceList{},
-		Requests: corev1.ResourceList{},
+	resources := cib.Spec.Resources
+
+	if resources.Limits == nil {
+		resources.Limits = corev1.ResourceList{}
 	}
+
+	if resources.Requests == nil {
+		resources.Requests = corev1.ResourceList{}
+	}
+
 	if cib.Spec.CPU != "" {
 		cpu, err := resource.ParseQuantity(cib.Spec.CPU)
 		if err != nil {
@@ -380,8 +386,8 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 
 	var tolerations []corev1.Toleration
 	if r.JobConfig.TolerationKey != "" {
-		tolerations = append(tolerations,  corev1.Toleration{
-			Key: r.JobConfig.TolerationKey,
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      r.JobConfig.TolerationKey,
 			Operator: "Exists",
 		})
 	}
@@ -404,7 +410,7 @@ func (r *ContainerImageBuildReconciler) createJobForBuild(ctx context.Context, c
 					InitContainers:     initContainers,
 					SecurityContext:    podSecCtx,
 					ImagePullSecrets:   imagePullSecrets,
-					Tolerations:	    tolerations,
+					Tolerations:        tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:            "forge-build",

--- a/controllers/containerimagebuild_resources_test.go
+++ b/controllers/containerimagebuild_resources_test.go
@@ -31,6 +31,27 @@ func TestContainerImageBuildReconciler_resourceLimits(t *testing.T) {
 		{
 			cib: &forgev1alpha1.ContainerImageBuild{
 				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cib-resources",
+				},
+				Spec: forgev1alpha1.ContainerImageBuildSpec{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"cpu":    resource.MustParse("666m"),
+							"memory": resource.MustParse("1G"),
+						},
+					},
+				},
+			},
+			resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("666m"),
+					"memory": resource.MustParse("1G"),
+				},
+			},
+		},
+		{
+			cib: &forgev1alpha1.ContainerImageBuild{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cib-resource-quota",
 				},
 				Spec: forgev1alpha1.ContainerImageBuildSpec{
@@ -215,8 +236,8 @@ func TestContainerImageBuildReconciler_tolerations(t *testing.T) {
 	job := &batchv1.Job{}
 	require.NoError(t, controller.Client.Get(context.Background(), types.NamespacedName{Name: cib.Name}, job))
 	expected := corev1.Toleration{
-			Key: "toleration1",
-			Operator: "Exists",
+		Key:      "toleration1",
+		Operator: "Exists",
 	}
 	assert.Contains(t, job.Spec.Template.Spec.Tolerations, expected)
 }


### PR DESCRIPTION
For example, this will allow setting a FUSE device resource request/limit to allow fuse-overlayfs to work.