### PR TITLE
remove asset publishing from release flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,11 @@ jobs:
             echo "export ACR_RG=forge${CIRCLE_BUILD_NUM}" >> $ACR_VARS
             echo "export ACR_LOCATION=westus2" >> $ACR_VARS
             . $ACR_VARS
+            cat $ACR_VARS >> $BASH_ENV
+
             az group create -n ${ACR_RG} -l ${ACR_LOCATION}
             az acr create -n ${ACR_NAME} -g ${ACR_RG} -l ${ACR_LOCATION} --sku Basic
             echo "export ACR_REGISTRY=$(az acr show -n ${ACR_NAME} -g ${ACR_RG} --query loginServer)" >> $ACR_VARS
-            cat $ACR_VARS >> $BASH_ENV
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,11 +93,11 @@ jobs:
             az group delete -y -n ${ACR_RG}
   test:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:202107-02
     environment:
       KUBECONFIG: "/etc/rancher/k3s/k3s.yaml"
-      HELM_VERSION: "v3.6.2"
-      KUSTOMIZE_VERSION: "v4.2.0"
+      HELM_VERSION: "v3.6.3"
+      KUSTOMIZE_VERSION: "v4.3.0"
       K3S_KUBECONFIG_MODE: "644"
     steps:
       - checkout
@@ -136,27 +136,7 @@ jobs:
           command: |
             az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}"
             az group delete -y -n ${ACR_RG}
-  publish_release:
-    executor: golang
-    environment:
-      GHR_VERSION: v0.14.0
-    steps:
-      - run:
-          name: Install ghr
-          command: go install -v github.com/tcnksm/ghr@${GHR_VERSION}
-      - attach_workspace:
-          at: ./artifacts
-      - run:
-          name: Publish GitHub Release
-          command: |
-            ghr \
-              -token ${GITHUB_TOKEN} \
-              -owner ${CIRCLE_PROJECT_USERNAME} \
-              -repository ${CIRCLE_PROJECT_REPONAME} \
-              -commitish ${CIRCLE_SHA1} \
-              -prerelease \
-              $(./artifacts/forge version) \
-              artifacts/
+
 workflows:
   version: 2
   main:
@@ -171,13 +151,5 @@ workflows:
           requires:
             - build
           filters:
-            tags:
-              only: /v\d+(\.\d+)*(-.*)*/
-      - publish_release:
-          requires:
-            - test
-          filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /v\d+(\.\d+)*(-.*)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
             az group create -n ${ACR_RG} -l ${ACR_LOCATION}
             az acr create -n ${ACR_NAME} -g ${ACR_RG} -l ${ACR_LOCATION} --sku Basic
-            echo "export ACR_REGISTRY=$(az acr show -n ${ACR_NAME} -g ${ACR_RG} --query loginServer)" >> $ACR_VARS
+            echo "export ACR_REGISTRY=$(az acr show -n ${ACR_NAME} -g ${ACR_RG} --query loginServer)" >> $BASH_ENV
       - persist_to_workspace:
           root: /tmp/workspace
           paths:


### PR DESCRIPTION
* The built assets aren't usable on their own and we publish docker images anyway.
* Updates the ACR testing to be a bit more resilient to failures like [this one](https://app.circleci.com/pipelines/github/dominodatalab/forge/673/workflows/b953537c-2f90-4585-af8c-1a2fb2d2fdaa/jobs/1227)